### PR TITLE
[Backup] Add error message on `mysqldump` not found

### DIFF
--- a/src/Command/BackupDatabasesCommand.php
+++ b/src/Command/BackupDatabasesCommand.php
@@ -82,6 +82,12 @@ final class BackupDatabasesCommand extends Command
 
         $mysqldump = (new ExecutableFinder())->find('mysqldump');
 
+        if (null === $mysqldump) {
+            $io->error('Cannot find "mysqldump" executable');
+
+            return Command::INVALID;
+        }
+
         /** @var Backup $backup */
         foreach ($backupsToExecute as $backup) {
             /** @var MySQLConnection $connection */


### PR DESCRIPTION
## Description
Added an error message when mysqldump executable is not found. Fixed #8 